### PR TITLE
Backend add rate limiter

### DIFF
--- a/Backend/middleware/rateLimiter.js
+++ b/Backend/middleware/rateLimiter.js
@@ -1,0 +1,10 @@
+const rateLimit = require('express-rate-limit')
+
+const limiter = rateLimit({
+    max: 10,
+    //10 seconds
+    windowMS: 10000,
+    message: "You can't make any more request at the moment. Try again later."
+})
+
+module.exports = limiter

--- a/Backend/middleware/rateLimiter.js
+++ b/Backend/middleware/rateLimiter.js
@@ -2,8 +2,8 @@ const rateLimit = require('express-rate-limit')
 
 const limiter = rateLimit({
     max: 10,
-    //10 seconds
-    windowMS: 10000,
+    //default is 60000 means 1 minute. Current wait time is around 10 seconds.
+    windowMs: 17000,
     message: "You can't make any more request at the moment. Try again later."
 })
 

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-async-handler": "^1.2.0",
+        "express-rate-limit": "^7.1.1",
         "mongodb": "4.0",
         "mongoose": "^7.4.5",
         "mongoose-sequence": "^5.3.1",
@@ -606,6 +607,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
       "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.1.tgz",
+      "integrity": "sha512-o5ye/a4EHCPQPju25Y4HChHybrCM9v37QtQDqXUDZGuD+HB7Cbu8ZhJP6/9RORcSNtkCpnEssa6oUgJgzc7ckQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
+    "express-rate-limit": "^7.1.1",
     "mongodb": "4.0",
     "mongoose": "^7.4.5",
     "mongoose-sequence": "^5.3.1",

--- a/Backend/routes/clientRoutes.js
+++ b/Backend/routes/clientRoutes.js
@@ -1,10 +1,11 @@
 const express = require("express");
 const router = express.Router();
 const clientsController = require("../controllers/clientsController");
+const limiter = require('../middleware/rateLimiter') 
 
 router
   .route("/")
-  .get(clientsController.getClients)
+  .get(limiter, clientsController.getClients)
   .post(clientsController.createClient);
 
 router.route("/:clientId").get(clientsController.getClient);

--- a/Frontend/frontend/src/components/ExistingClient.jsx
+++ b/Frontend/frontend/src/components/ExistingClient.jsx
@@ -12,15 +12,23 @@ const ExistingClient = () => {
   const [clientPerPage] = useState(5);
   const [isUserFound, setIsUserFound] = useState(true);
   const [phone, setPhone] = useState("");
+  const [err, setErr] = useState(null);
   const nameSearch = useRef(null);
   const birthdaySearch = useRef(null);
 
   useEffect(() => {
-    axios.get("http://localhost:3500/clients").then((res) => {
-      setClients(res.data);
-      setFilteredClients(res.data);
-      setLoading(false);
-    });
+    axios
+      .get("http://localhost:3500/clients")
+      .then((res) => {
+        setClients(res.data);
+        setFilteredClients(res.data);
+        setLoading(false);
+        setErr(null);
+      })
+      .catch((err) => {
+        setLoading(false);
+        setErr(err.response.data);
+      });
   }, []);
 
   const indexOfLastClient = currentPage * clientPerPage;
@@ -82,7 +90,7 @@ const ExistingClient = () => {
           <h1 className="text-red-500 text-xl">User Not Found</h1>
         ) : (
           <>
-            <Table clients={currentClients} loading={loading} />
+            <Table clients={currentClients} loading={loading} err={err} />
             <Pagination
               currentPage={currentPage}
               userPerPage={clientPerPage}

--- a/Frontend/frontend/src/components/Table.jsx
+++ b/Frontend/frontend/src/components/Table.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 
-const Table = ({ clients, loading }) => {
+const Table = ({ clients, loading, err }) => {
   if (loading) {
     return <h2>Loading...</h2>;
   }
-
+  if (err) {
+    console.log(err);
+    return <h2>{err}</h2>;
+  }
   const formatPhoneNumber = (phoneNumber) => {
     let strNum = String(phoneNumber);
 
@@ -38,14 +41,7 @@ const Table = ({ clients, loading }) => {
       </thead>
       <tbody className="text-lg">
         {clients.map(
-          ({
-            _id,
-            firstName,
-            lastName,
-            email,
-            birthday,
-            phoneNumber,
-          }) => (
+          ({ _id, firstName, lastName, email, birthday, phoneNumber }) => (
             <tr key={_id}>
               <td>{firstName}</td>
               <td>{lastName}</td>


### PR DESCRIPTION
I added the rate limiter middleware. Now the developer can import anywhere and limit the API requets for that endpoint.
Here is an example at localhost:3500/clients after request the same URL for 10 times within 10 seconds. 
<img width="640" alt="image" src="https://github.com/mengzhuou/BizWeb/assets/98554622/dc51ab95-bbd6-4241-afab-d04d3dba6fcb">
Here is the code with customizable values
<img width="468" alt="image" src="https://github.com/mengzhuou/BizWeb/assets/98554622/8b39c48e-5c41-4dc2-85bf-190c04d4bfcd">
I also edited the frontend to match with the err message.
<img width="959" alt="image" src="https://github.com/mengzhuou/BizWeb/assets/98554622/349c44fb-9d99-452d-8de6-27c0cb89df09">


